### PR TITLE
Add low-level design documentation and tasks list

### DIFF
--- a/specification/design.md
+++ b/specification/design.md
@@ -1,0 +1,29 @@
+# Low-Level Design: SvelteKit Component Library
+
+## Directory Structure
+- `src/lib/components/<Component>/` – each component lives in its own folder.
+- `src/lib/components/<Component>/<Component>.svelte` – component implementation.
+- `src/lib/components/<Component>/index.ts` – export entry.
+- `src/lib/utils/` – shared utilities.
+- `src/routes/` – demo and integration playground.
+
+## Component Anatomy
+- Props declared with `export let` and typed via TypeScript.
+- Slots expose custom content; default slot for markup.
+- Events dispatched using `createEventDispatcher`.
+- Each component exports an interface for public API.
+
+## Styling
+- Tailwind CSS provides base styling and tokens.
+- Theme configuration lives in `tailwind.config.js`.
+- Components leverage the Skeleton plugin and `tailwind-variants` for variants.
+
+## Documentation and Testing
+- Storybook stories reside alongside components (`Component.stories.ts`).
+- Unit tests written with Vitest (`Component.test.ts`).
+- End-to-end tests executed with Playwright in `e2e/`.
+- `npm test` runs unit and e2e suites.
+
+## Packaging
+- `svelte-package` bundles the library into `dist/`.
+- Root `index.ts` re-exports all component modules.

--- a/specification/tasks.md
+++ b/specification/tasks.md
@@ -1,0 +1,25 @@
+# Coding Tasks
+
+## App Navigation UI
+- Implement sticky top bar with centered logo linking to home.
+- Add burger menu button to toggle left slide-in navigation panel.
+- Build navigation panel with composable item components, section grouping, and close on outside click or `Esc`.
+- Show authentication state in right corner: login button when logged out, avatar with popover (Preferences, Account, Log out) when logged in.
+- Include three-dot settings trigger routing to settings page or panel.
+- Ensure theming support and responsive behavior (mobile full-screen panel, desktop ~320px width).
+
+## Component Library Infrastructure
+- Organize components under `src/lib/components/<Component>/` with implementation, `index.ts`, stories, and tests.
+- Provide shared utilities in `src/lib/utils/` (e.g., `cn`, types helpers).
+- Style components using Tailwind CSS, Skeleton plugin, and `tailwind-variants` for variants.
+- Set up Storybook stories (`Component.stories.ts`) and Vitest unit tests (`Component.test.ts`).
+- Configure Playwright E2E tests in `e2e/` and run via `npm test`.
+- Bundle library with `svelte-package`; re-export modules from root `index.ts`.
+
+## Product Roadmap
+- Integrate Skeleton default theme and wrap base components.
+- Implement ThemeProvider store with runtime light/dark switching and custom theme support.
+- Expand component set: Button, Input, Select, Modal, Toast, Tabs, Accordion, Navbar.
+- Write Storybook MDX guides, interactive stories, and autodocs.
+- Add unit tests per component and expand Playwright scenarios for complex interactions.
+- Configure CI/CD pipeline: lint → unit tests → build → Storybook deploy, optional Chromatic visual regression.


### PR DESCRIPTION
## Summary
- add low-level design spec for SvelteKit component library
- create coding tasks list derived from specifications

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68c755d6689883279a5aa365754af4ed