### PR TITLE
Add low-level design documentation and tasks list

### DIFF
--- a/specification/design.md
+++ b/specification/design.md
@@ -1,0 +1,29 @@
+# Low-Level Design: SvelteKit Component Library
+
+## Directory Structure
+- `src/lib/components/<Component>/` – each component lives in its own folder.
+- `src/lib/components/<Component>/<Component>.svelte` – component implementation.
+- `src/lib/components/<Component>/index.ts` – export entry.
+- `src/lib/utils/` – shared utilities.
+- `src/routes/` – demo and integration playground.
+
+## Component Anatomy
+- Props declared with `export let` and typed via TypeScript.
+- Slots expose custom content; default slot for markup.
+- Events dispatched using `createEventDispatcher`.
+- Each component exports an interface for public API.
+
+## Styling
+- Tailwind CSS provides base styling and tokens.
+- Theme configuration lives in `tailwind.config.js`.
+- Components leverage the Skeleton plugin and `tailwind-variants` for variants.
+
+## Documentation and Testing
+- Storybook stories reside alongside components (`Component.stories.ts`).
+- Unit tests written with Vitest (`Component.test.ts`).
+- End-to-end tests executed with Playwright in `e2e/`.
+- `npm test` runs unit and e2e suites.
+
+## Packaging
+- `svelte-package` bundles the library into `dist/`.
+- Root `index.ts` re-exports all component modules.

--- a/specification/tasks.md
+++ b/specification/tasks.md
@@ -1,0 +1,25 @@
+# Coding Tasks
+
+## App Navigation UI
+- Implement sticky top bar with centered logo linking to home.
+- Add burger menu button to toggle left slide-in navigation panel.
+- Build navigation panel with composable item components, section grouping, and close on outside click or `Esc`.
+- Show authentication state in right corner: login button when logged out, avatar with popover (Preferences, Account, Log out) when logged in.
+- Include three-dot settings trigger routing to settings page or panel.
+- Ensure theming support and responsive behavior (mobile full-screen panel, desktop ~320px width).
+
+## Component Library Infrastructure
+- Organize components under `src/lib/components/<Component>/` with implementation, `index.ts`, stories, and tests.
+- Provide shared utilities in `src/lib/utils/` (e.g., `cn`, types helpers).
+- Style components using Tailwind CSS, Skeleton plugin, and `tailwind-variants` for variants.
+- Set up Storybook stories (`Component.stories.ts`) and Vitest unit tests (`Component.test.ts`).
+- Configure Playwright E2E tests in `e2e/` and run via `npm test`.
+- Bundle library with `svelte-package`; re-export modules from root `index.ts`.
+
+## Product Roadmap
+- Integrate Skeleton default theme and wrap base components.
+- Implement ThemeProvider store with runtime light/dark switching and custom theme support.
+- Expand component set: Button, Input, Select, Modal, Toast, Tabs, Accordion, Navbar.
+- Write Storybook MDX guides, interactive stories, and autodocs.
+- Add unit tests per component and expand Playwright scenarios for complex interactions.
+- Configure CI/CD pipeline: lint → unit tests → build → Storybook deploy, optional Chromatic visual regression.

--- a/src/lib/components/navbar/NavItem.svelte
+++ b/src/lib/components/navbar/NavItem.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { cn } from '$lib/utils.js';
+  export let href: string | undefined = undefined;
+  export let active = false;
+  export let disabled = false;
+  export let className: string | undefined = undefined;
+  const dispatch = createEventDispatcher<{ click: MouseEvent }>();
+  function handleClick(event: MouseEvent) {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+    dispatch('click', event);
+  }
+</script>
+
+<a
+  class={cn(
+    'flex items-center gap-2 rounded px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
+    active && 'bg-accent text-accent-foreground',
+    disabled && 'pointer-events-none opacity-50',
+    className
+  )}
+  {href}
+  aria-current={active ? 'page' : undefined}
+  aria-disabled={disabled}
+  on:click={handleClick}
+>
+  <slot name="left" />
+  <slot />
+  <slot name="right" />
+</a>

--- a/src/lib/components/navbar/NavPanel.svelte
+++ b/src/lib/components/navbar/NavPanel.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+  import { fly } from 'svelte/transition';
+  export let open = false;
+  const dispatch = createEventDispatcher();
+  function close() {
+    dispatch('close');
+  }
+  function handleKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      close();
+    }
+  }
+  onMount(() => document.addEventListener('keydown', handleKey));
+  onDestroy(() => document.removeEventListener('keydown', handleKey));
+</script>
+
+{#if open}
+<div class="fixed inset-0 z-40">
+  <button
+    type="button"
+    class="absolute inset-0 bg-black/50"
+    aria-label="Close navigation panel"
+    on:click={close}
+  ></button>
+  <nav
+    in:fly={{ x: -320 }}
+    out:fly={{ x: -320 }}
+    class="relative h-full w-full max-w-xs bg-background p-4 overflow-y-auto sm:w-80"
+  >
+    <slot />
+  </nav>
+</div>
+{/if}

--- a/src/lib/components/navbar/Navbar.svelte
+++ b/src/lib/components/navbar/Navbar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import NavPanel from './NavPanel.svelte';
+  import NavItem from './NavItem.svelte';
+  import Button from '$lib/components/ui/button/button.svelte';
+  let panelOpen = false;
+  let userMenuOpen = false;
+  let loggedIn = false;
+  function togglePanel() {
+    panelOpen = !panelOpen;
+  }
+  function closePanel() {
+    panelOpen = false;
+  }
+  function toggleUserMenu() {
+    userMenuOpen = !userMenuOpen;
+  }
+  function logOut() {
+    loggedIn = false;
+    userMenuOpen = false;
+  }
+</script>
+
+<div class="sticky top-0 z-50 w-full border-b bg-background">
+  <div class="relative flex h-14 items-center justify-between px-4">
+    <button
+      class="mr-2 rounded p-2 focus:outline-none focus:ring"
+      aria-label="Open navigation"
+      on:click={togglePanel}
+    >
+      &#9776;
+    </button>
+    <a href="/" class="absolute left-1/2 -translate-x-1/2 text-lg font-bold">Altius</a>
+    <div class="flex items-center gap-2">
+      {#if loggedIn}
+        <div class="relative">
+          <button
+            class="flex h-8 w-8 items-center justify-center rounded-full bg-accent text-accent-foreground"
+            aria-haspopup="menu"
+            aria-expanded={userMenuOpen}
+            on:click={toggleUserMenu}
+          >
+            U
+          </button>
+          {#if userMenuOpen}
+            <div class="absolute right-0 mt-2 w-40 rounded-md border bg-popover p-2 text-sm shadow">
+              <a class="block rounded px-2 py-1 hover:bg-accent hover:text-accent-foreground" href="/preferences">Preferences</a>
+              <a class="block rounded px-2 py-1 hover:bg-accent hover:text-accent-foreground" href="/account">Account</a>
+              <button class="block w-full rounded px-2 py-1 text-left hover:bg-accent hover:text-accent-foreground" on:click={logOut}>Log out</button>
+            </div>
+          {/if}
+        </div>
+      {:else}
+        <Button on:click={() => (loggedIn = true)}>Log in</Button>
+      {/if}
+      <a href="/settings" aria-label="Settings" class="rounded p-2 hover:bg-accent hover:text-accent-foreground">&#8942;</a>
+    </div>
+  </div>
+</div>
+
+<NavPanel open={panelOpen} on:close={closePanel}>
+  <NavItem href="/" active>Home</NavItem>
+  <NavItem href="/about">About</NavItem>
+</NavPanel>

--- a/src/lib/components/navbar/index.ts
+++ b/src/lib/components/navbar/index.ts
@@ -1,0 +1,5 @@
+import Navbar from './Navbar.svelte';
+import NavPanel from './NavPanel.svelte';
+import NavItem from './NavItem.svelte';
+
+export { Navbar, NavPanel, NavItem };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,2 @@
-// Reexport your entry components here
+export * from './components/ui/button';
+export * from './components/navbar';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import '../app.css';
-	
-	let { children } = $props();
+        import '../app.css';
+        import { Navbar } from '$lib';
+        let { children } = $props();
 </script>
 
+<Navbar />
 {@render children()}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,0 +1,1 @@
+<h1 class="p-4 text-xl">About</h1>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -1,0 +1,1 @@
+<h1 class="p-4 text-xl">Account</h1>

--- a/src/routes/preferences/+page.svelte
+++ b/src/routes/preferences/+page.svelte
@@ -1,0 +1,1 @@
+<h1 class="p-4 text-xl">Preferences</h1>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,1 @@
+<h1 class="p-4 text-xl">Settings</h1>


### PR DESCRIPTION
## Summary
- add low-level design spec for SvelteKit component library
- create coding tasks list derived from specifications
- implement navigation bar with slide-in panel and user menu
- fix navigation panel overlay accessibility with a button overlay

## Testing
- `npm run dev`
- `npm run build`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68c755d6689883279a5aa365754af4ed